### PR TITLE
Fix for collector version 0.104.0

### DIFF
--- a/docker/config-aspire.yaml
+++ b/docker/config-aspire.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: collector:4317
       http:
+        endpoint: collector:4318
 
 processors:
   batch:

--- a/docker/config-full.yaml
+++ b/docker/config-full.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: collector:4317
       http:
+        endpoint: collector:4318
 
 processors:
   batch:

--- a/docker/config-metrics.yaml
+++ b/docker/config-metrics.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: collector:4317
       http:
+        endpoint: collector:4318
 
 processors:
   batch:

--- a/docker/config-with-sampling.yaml
+++ b/docker/config-with-sampling.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: collector:4317
       http:
+        endpoint: collector:4318
 
 processors:
   batch:


### PR DESCRIPTION
You probably already know this, but the change in the collector in version 0.104.0 means we now need to set the endpoint for the receivers (at least it did for me) You don't need to take this PR... but I figured I'd mention it in case you hadn't run into the issue yet.